### PR TITLE
Feat/upgradesparkpoolversion function 18032026

### DIFF
--- a/functions/entity_registry.py
+++ b/functions/entity_registry.py
@@ -106,6 +106,8 @@ def build_entity_spec(entity_key: str) -> EntitySpec:
     wake_subscription = None
     if entity_key == "appeal-document":
         wake_subscription = "appeal-document-odw-wake-sub"
+    if entity_key == "appeal-has":
+        wake_subscription = "appeal-has-odw-wake-sub"
 
     return EntitySpec(
         key=entity_key,

--- a/functions/entity_registry.py
+++ b/functions/entity_registry.py
@@ -108,6 +108,18 @@ def build_entity_spec(entity_key: str) -> EntitySpec:
         wake_subscription = "appeal-document-odw-wake-sub"
     if entity_key == "appeal-has":
         wake_subscription = "appeal-has-odw-wake-sub"
+    if entity_key == "appeal-event":
+        wake_subscription = "appeal-event-odw-wake-sub"
+    if entity_key == "appeal-event-estimate":
+        wake_subscription = "appeal-event-estimate-odw-wake-sub"
+    if entity_key == "appeal-event-estimate":
+        wake_subscription = "appeal-event-estimate-odw-wake-sub"
+    if entity_key == "appeal-service-user":
+        wake_subscription = "appeal-service-user-odw-wake-sub"
+    if entity_key == "appeal-s78":
+        wake_subscription = "appeal-s78-odw-wake-sub"
+    if entity_key == "appeal-representation":
+        wake_subscription = "appeal-representation-odw-wake-sub"
 
     return EntitySpec(
         key=entity_key,

--- a/functions/entity_registry.py
+++ b/functions/entity_registry.py
@@ -120,6 +120,25 @@ def build_entity_spec(entity_key: str) -> EntitySpec:
         wake_subscription = "appeal-s78-odw-wake-sub"
     if entity_key == "appeal-representation":
         wake_subscription = "appeal-representation-odw-wake-sub"
+    if entity_key == "folder":
+        wake_subscription = "folder-odw-wake-sub"
+    if entity_key == "service-user":
+        wake_subscription = "service-user-odw-wake-sub"
+    if entity_key == "nsip-document":
+        wake_subscription = "nsip-document-odw-wake-sub"
+    if entity_key == "nsip-exam-timetable":
+        wake_subscription = "nsip-exam-timetable-odw-wake-sub"
+    if entity_key == "nsip-project":
+        wake_subscription = "nsip-project-odw-wake-sub"
+    if entity_key == "nsip-project-update":
+        wake_subscription = "nsip-project-update-odw-wake-sub"
+    if entity_key == "nsip-representation":
+        wake_subscription = "nsip-representation-odw-wake-sub"
+    if entity_key == "nsip-s51-advice":
+            wake_subscription = "nsip-s51-advice-odw-wake-sub"
+    if entity_key == "nsip-subscription":
+           wake_subscription = "nsip-subscription-odw-wake-sub"
+
 
     return EntitySpec(
         key=entity_key,

--- a/functions/entity_registry.py
+++ b/functions/entity_registry.py
@@ -1,3 +1,4 @@
+
 """
 Entity registry for ODW Azure Functions
 
@@ -21,6 +22,50 @@ from typing import Optional
 from set_environment import config
 
 
+# -----------------------------
+# Centralised config & overrides
+# -----------------------------
+
+# Wake & Drain: entities that get a wake subscription
+WAKE_DRAIN_ENABLED_ENTITY_KEYS = {
+    "appeal-document",
+    "appeal-has",
+    "appeal-event",
+    "appeal-event-estimate",
+    "appeal-service-user",
+    "appeal-s78",
+    "appeal-representation",
+    "folder",
+    "service-user",
+    "nsip-document",
+    "nsip-exam-timetable",
+    "nsip-project",
+    "nsip-project-update",
+    "nsip-representation",
+    "nsip-s51-advice",
+    "nsip-subscription",
+}
+
+# Some entities have schema filenames that don't match the entity key pattern
+SCHEMA_OVERRIDES = {
+    "appeal-service-user": "service-user.schema.json",
+    "nsip-s51-advice": "s51-advice.schema.json",
+}
+
+# HTTP route overrides (defaults to key with hyphens removed)
+HTTP_ROUTE_OVERRIDES = {
+    "nsip-s51-advice": "s51advice",
+}
+
+# Storage folder overrides (defaults to topic)
+STORAGE_ENTITY_OVERRIDES = {
+    "nsip-s51-advice": "s51-advice",
+    "appeal-service-user": "service-user",
+    "appeal-s78": "appeal-s78",
+    "appeal-representation": "appeal-representation",
+}
+
+
 @dataclass(frozen=True)
 class EntitySpec:
     """
@@ -28,8 +73,10 @@ class EntitySpec:
     """
     key: str  # e.g. "appeal-document"
     topic: str
-    subscription: str  # the REAL subscription we drain (e.g. appeal-document-odw-sub)
-    schema_filename: str  # e.g. "appeal-document.schema.json"
+    # The REAL subscription we drain (e.g. appeal-document-odw-sub)
+    subscription: str
+    # e.g. "appeal-document.schema.json"
+    schema_filename: str
 
     # Service Bus connection prefix (identity based) for trigger binding
     sb_connection: str
@@ -37,13 +84,13 @@ class EntitySpec:
     # HTTP pull uses explicit namespace env vars
     http_namespace_env_var: str
 
-    # Storage folder name override (rare cases - I think like nsip-project)
+    # Storage folder name override (rare cases - e.g. nsip-project)
     storage_entity_override: Optional[str] = None
 
     # HTTP route override (normally key without hyphens)
     http_route: Optional[str] = None
 
-    # Optional wake subscription that triggers the function (wake only, we do NOT drain this)
+    # Optional wake subscription that triggers the function (wake only; we do NOT drain this)
     wake_subscription: Optional[str] = None
 
     @property
@@ -55,8 +102,10 @@ class EntitySpec:
         return self.http_route or self.key.replace("-", "")
 
     @property
-    def trigger_subscription(self) -> str:
-        return self.wake_subscription or self.subscription
+    def trigger_subscription(self) -> Optional[str]:
+        # IMPORTANT: Do NOT fall back to the real subscription here.
+        # This field is specifically the WAKE (trigger) subscription or None.
+        return self.wake_subscription
 
 
 def _is_appeals_entity(entity_key: str) -> bool:
@@ -71,74 +120,34 @@ def build_entity_spec(entity_key: str) -> EntitySpec:
     topic = entity_cfg["topic"]
     subscription = entity_cfg["subscription"]
 
-    schema_filename = f"{entity_key}.schema.json"
+    # schema (default follows the "<entity_key>.schema.json" convention)
+    schema_filename = SCHEMA_OVERRIDES.get(
+        entity_key, f"{entity_key}.schema.json"
+    )
 
-    # overriding schemas here for entity_key naming that don't match their schema
-    SCHEMA_OVERRIDES = {
-        "appeal-service-user": "service-user.schema.json",
-        "nsip-s51-advice": "s51-advice.schema.json",
-    }
-
-    schema_filename = SCHEMA_OVERRIDES.get(entity_key, schema_filename)
-
+    # connection prefixes / http namespace env var
     if _is_appeals_entity(entity_key):
         sb_connection = "ServiceBusConnectionAppeals"
         http_namespace_env_var = "SERVICEBUS_NAMESPACE_APPEALS"
     else:
         sb_connection = "ServiceBusConnection"
+        # this is what you already use elsewhere for non-appeals http namespace
         http_namespace_env_var = "ServiceBusConnection__fullyQualifiedNamespace"
 
-    http_route = entity_key.replace("-", "")
-    if entity_key == "nsip-s51-advice":
-        http_route = "s51advice"
+    # http route (default: strip hyphens) with override
+    http_route = HTTP_ROUTE_OVERRIDES.get(
+        entity_key, entity_key.replace("-", "")
+    )
 
-    storage_override = None
-    if entity_key == "nsip-s51-advice":
-        storage_override = "s51-advice"
-    if entity_key == "appeal-service-user":
-        storage_override = "service-user"
-    if entity_key == "appeal-s78":
-        storage_override = "appeal-s78"
-    if entity_key == "appeal-representation":
-        storage_override = "appeal-representation"
+    # storage entity override if any (default later: topic)
+    storage_override = STORAGE_ENTITY_OVERRIDES.get(entity_key)
 
-    # Wake subscription (pilot only for now)
-    wake_subscription = None
-    if entity_key == "appeal-document":
-        wake_subscription = "appeal-document-odw-wake-sub"
-    if entity_key == "appeal-has":
-        wake_subscription = "appeal-has-odw-wake-sub"
-    if entity_key == "appeal-event":
-        wake_subscription = "appeal-event-odw-wake-sub"
-    if entity_key == "appeal-event-estimate":
-        wake_subscription = "appeal-event-estimate-odw-wake-sub"
-    if entity_key == "appeal-event-estimate":
-        wake_subscription = "appeal-event-estimate-odw-wake-sub"
-    if entity_key == "appeal-service-user":
-        wake_subscription = "appeal-service-user-odw-wake-sub"
-    if entity_key == "appeal-s78":
-        wake_subscription = "appeal-s78-odw-wake-sub"
-    if entity_key == "appeal-representation":
-        wake_subscription = "appeal-representation-odw-wake-sub"
-    if entity_key == "folder":
-        wake_subscription = "folder-odw-wake-sub"
-    if entity_key == "service-user":
-        wake_subscription = "service-user-odw-wake-sub"
-    if entity_key == "nsip-document":
-        wake_subscription = "nsip-document-odw-wake-sub"
-    if entity_key == "nsip-exam-timetable":
-        wake_subscription = "nsip-exam-timetable-odw-wake-sub"
-    if entity_key == "nsip-project":
-        wake_subscription = "nsip-project-odw-wake-sub"
-    if entity_key == "nsip-project-update":
-        wake_subscription = "nsip-project-update-odw-wake-sub"
-    if entity_key == "nsip-representation":
-        wake_subscription = "nsip-representation-odw-wake-sub"
-    if entity_key == "nsip-s51-advice":
-            wake_subscription = "nsip-s51-advice-odw-wake-sub"
-    if entity_key == "nsip-subscription":
-           wake_subscription = "nsip-subscription-odw-wake-sub"
-
+    # Wake subscription (centralised logic derived from the enabled set)
+    wake_subscription = (
+        f"{entity_key}-odw-wake-sub"
+        if entity_key in WAKE_DRAIN_ENABLED_ENTITY_KEYS
+        else None
+    )
 
     return EntitySpec(
         key=entity_key,

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -44,7 +44,7 @@ _app = func.FunctionApp()
 
 # Pilot toggle Wake & Drain
 # Later: set to all entities OR via env var (which would be better tbh)
-_WAKE_DRAIN_ENABLED_ENTITY_KEYS = {"appeal-document","appeal-has"}
+_WAKE_DRAIN_ENABLED_ENTITY_KEYS = {"appeal-document","appeal-has","appeal-event","appeal-event-estimate","appeal-service-user","appeal-s78","appeal-representation"}
 
 
 def _make_http_pull_handler(entity: EntitySpec) -> Callable[[func.HttpRequest], func.HttpResponse]:

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -44,7 +44,7 @@ _app = func.FunctionApp()
 
 # Pilot toggle Wake & Drain
 # Later: set to all entities OR via env var (which would be better tbh)
-_WAKE_DRAIN_ENABLED_ENTITY_KEYS = {"appeal-document"}
+_WAKE_DRAIN_ENABLED_ENTITY_KEYS = {"appeal-document","appeal-has"}
 
 
 def _make_http_pull_handler(entity: EntitySpec) -> Callable[[func.HttpRequest], func.HttpResponse]:

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -19,7 +19,7 @@ from pins_data_model import load_schemas
 from var_funcs import CREDENTIAL
 from set_environment import config
 from servicebus_funcs import get_messages_and_validate, send_to_storage
-from entity_registry import EntitySpec, all_entities,WAKE_DRAIN_ENABLED_ENTITY_KEYS
+from entity_registry import EntitySpec, all_entities
 from sb_wake_drain_processor import process_wake_and_drain
 
 # Environment
@@ -97,12 +97,11 @@ def _make_http_pull_handler(entity: EntitySpec) -> Callable[[func.HttpRequest], 
 def _make_wake_drain_trigger_handler(entity: EntitySpec) -> Callable[[func.ServiceBusMessage], None]:
     """
     Builds a Service Bus trigger handler for an entity
-    The trigger listens to entity.trigger_subscription (the wake subscription)
-    The draining is performed against entity.subscription (the real subscription for e.g appeal-document-odw-sub)
+    The trigger listens to entity.wake_subscription (the wake subscription)
+    The draining is performed against entity.subscription (the real subscription, e.g. appeal-document-odw-sub)
     """
     def _handler(msg: func.ServiceBusMessage) -> None:
         schema = _SCHEMAS[entity.schema_filename]
-
         namespace = os.environ.get(entity.http_namespace_env_var, "")
 
         process_wake_and_drain(
@@ -129,19 +128,15 @@ for entity in all_entities():
         )
     )
 
-    if entity.key in WAKE_DRAIN_ENABLED_ENTITY_KEYS:
-        if not entity.wake_subscription:
-            raise ValueError(
-                f"Wake&Drain enabled for {entity.key} but no wake_subscription is configured"
-            )
-
+    # ✅ Only rely on the registry-provided wake/trigger subscription
+    if entity.wake_subscription:  # or: if entity.trigger_subscription
         sb_fn_name = f"{entity.route}_wake_drain"
 
         _app.function_name(sb_fn_name)(
             _app.service_bus_topic_trigger(
                 arg_name="msg",
                 topic_name=entity.topic,
-                subscription_name=entity.trigger_subscription,
+                subscription_name=entity.wake_subscription,  # or: entity.trigger_subscription
                 connection=entity.sb_connection,
             )(
                 _make_wake_drain_trigger_handler(entity)

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -19,7 +19,7 @@ from pins_data_model import load_schemas
 from var_funcs import CREDENTIAL
 from set_environment import config
 from servicebus_funcs import get_messages_and_validate, send_to_storage
-from entity_registry import EntitySpec, all_entities
+from entity_registry import EntitySpec, all_entities,WAKE_DRAIN_ENABLED_ENTITY_KEYS
 from sb_wake_drain_processor import process_wake_and_drain
 
 # Environment
@@ -44,8 +44,7 @@ _app = func.FunctionApp()
 
 # Pilot toggle Wake & Drain
 # Later: set to all entities OR via env var (which would be better tbh)
-_WAKE_DRAIN_ENABLED_ENTITY_KEYS = {"appeal-document","appeal-has","appeal-event","appeal-event-estimate","appeal-service-user","appeal-s78","appeal-representation","folder","nsip-project","service-user",
-                                   "nsip-document","nsip-exam-timetable","nsip-project-update","nsip-representation","nsip-s51-advice","nsip-subscription"}
+
 
 
 def _make_http_pull_handler(entity: EntitySpec) -> Callable[[func.HttpRequest], func.HttpResponse]:
@@ -130,7 +129,7 @@ for entity in all_entities():
         )
     )
 
-    if entity.key in _WAKE_DRAIN_ENABLED_ENTITY_KEYS:
+    if entity.key in WAKE_DRAIN_ENABLED_ENTITY_KEYS:
         if not entity.wake_subscription:
             raise ValueError(
                 f"Wake&Drain enabled for {entity.key} but no wake_subscription is configured"

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -44,7 +44,8 @@ _app = func.FunctionApp()
 
 # Pilot toggle Wake & Drain
 # Later: set to all entities OR via env var (which would be better tbh)
-_WAKE_DRAIN_ENABLED_ENTITY_KEYS = {"appeal-document","appeal-has","appeal-event","appeal-event-estimate","appeal-service-user","appeal-s78","appeal-representation"}
+_WAKE_DRAIN_ENABLED_ENTITY_KEYS = {"appeal-document","appeal-has","appeal-event","appeal-event-estimate","appeal-service-user","appeal-s78","appeal-representation","folder","nsip-project","service-user",
+                                   "nsip-document","nsip-exam-timetable","nsip-project-update","nsip-representation","nsip-s51-advice","nsip-subscription"}
 
 
 def _make_http_pull_handler(entity: EntitySpec) -> Callable[[func.HttpRequest], func.HttpResponse]:

--- a/functions/servicebus_funcs.py
+++ b/functions/servicebus_funcs.py
@@ -13,7 +13,6 @@ from azure.storage.blob import BlobServiceClient
 import json
 from validate_messages import validate_data
 
-
 def get_messages_and_validate(
     namespace: str,
     credential: DefaultAzureCredential,
@@ -156,6 +155,7 @@ def send_to_storage(
     _CURRENT_DATE = current_date()
     _CURRENT_TIME = current_time()
     _FILENAME = f"{entity}/{_CURRENT_DATE}/{entity}_{_CURRENT_TIME}.json"
+       
 
     try:
         if data:

--- a/functions/servicebus_funcs.py
+++ b/functions/servicebus_funcs.py
@@ -152,10 +152,11 @@ def send_to_storage(
 
     from var_funcs import current_date, current_time
 
+  
     _CURRENT_DATE = current_date()
-    _CURRENT_TIME = current_time()
+    _CURRENT_TIME = current_time().replace(":", "_")
     _FILENAME = f"{entity}/{_CURRENT_DATE}/{entity}_{_CURRENT_TIME}.json"
-       
+
 
     try:
         if data:


### PR DESCRIPTION
This change updates the blob filename pattern used when persisting Service Bus messages so that timestamps no longer contain colon characters.

Previously, current_time() returned a value like 2026-03-18T17:16:12.894548+0000, which was used directly in the blob name. Some Spark runtimes (notably our Spark 3.4 pool) treat : in the path as an invalid URI character, causing failures when reading JSON from the raw layer.

The function now replaces : with _ when building the filename:

python
_CURRENT_DATE = current_date()
_CURRENT_TIME = current_time().replace(":", "_")
_FILENAME = f"{entity}/{_CURRENT_DATE}/{entity}_{_CURRENT_TIME}.json"