### PR TITLE
Adding Wake & Drain

### DIFF
--- a/functions/entity_registry.py
+++ b/functions/entity_registry.py
@@ -28,6 +28,7 @@ SCHEMA_OVERRIDES = {
 
 STORAGE_OVERRIDES = {
     "nsip-s51-advice": "s51-advice",
+    "appeal-service-user": "service-user",
 }
 
 # Wake subscription

--- a/functions/entity_registry.py
+++ b/functions/entity_registry.py
@@ -21,18 +21,19 @@ from typing import Optional
 from set_environment import config
 
 # overriding schemas here for entity_key naming that don't match their schema
-SCHEMA_OVERRIDES = {
+_SCHEMA_OVERRIDES = {
     "appeal-service-user": "service-user.schema.json",
     "nsip-s51-advice": "s51-advice.schema.json",
 }
 
-STORAGE_OVERRIDES = {
+_STORAGE_OVERRIDES = {
     "nsip-s51-advice": "s51-advice",
     "appeal-service-user": "service-user",
 }
 
-# Wake subscription
-WAKE_SUBSCRIPTION_OVERRIDES = {
+# Wake subscriptions used by SB trigger
+# Entities not listed here remain HTTP pull only
+_WAKE_SUBSCRIPTION_OVERRIDES = {
     "nsip-document": "odw-nsip-document-wake-sub",
     "nsip-exam-timetable": "odw-nsip-exam-timetable-wake-sub",
     "nsip-project": "odw-nsip-project-wake-sub",
@@ -104,7 +105,7 @@ def build_entity_spec(entity_key: str) -> EntitySpec:
 
     schema_filename = f"{entity_key}.schema.json"
 
-    schema_filename = SCHEMA_OVERRIDES.get(entity_key, schema_filename)
+    schema_filename = _SCHEMA_OVERRIDES.get(entity_key, schema_filename)
 
     if _is_appeals_entity(entity_key):
         sb_connection = "ServiceBusConnectionAppeals"
@@ -117,9 +118,9 @@ def build_entity_spec(entity_key: str) -> EntitySpec:
     if entity_key == "nsip-s51-advice":
         http_route = "s51advice"
 
-    storage_override = STORAGE_OVERRIDES.get(entity_key)
+    storage_override = _STORAGE_OVERRIDES.get(entity_key)
 
-    wake_subscription = WAKE_SUBSCRIPTION_OVERRIDES.get(entity_key)
+    wake_subscription = _WAKE_SUBSCRIPTION_OVERRIDES.get(entity_key)
 
     return EntitySpec(
         key=entity_key,

--- a/functions/entity_registry.py
+++ b/functions/entity_registry.py
@@ -20,6 +20,36 @@ from typing import Optional
 
 from set_environment import config
 
+# overriding schemas here for entity_key naming that don't match their schema
+SCHEMA_OVERRIDES = {
+    "appeal-service-user": "service-user.schema.json",
+    "nsip-s51-advice": "s51-advice.schema.json",
+}
+
+STORAGE_OVERRIDES = {
+    "nsip-s51-advice": "s51-advice",
+}
+
+# Wake subscription
+WAKE_SUBSCRIPTION_OVERRIDES = {
+    "nsip-document": "odw-nsip-document-wake-sub",
+    "nsip-exam-timetable": "odw-nsip-exam-timetable-wake-sub",
+    "nsip-project": "odw-nsip-project-wake-sub",
+    "nsip-project-update": "odw-nsip-project-update-wake-sub",
+    "nsip-representation": "odw-nsip-representation-wake-sub",
+    "nsip-s51-advice": "odw-nsip-s51-advice-wake-sub",
+    "nsip-subscription": "odw-nsip-subscription-wake-sub",
+    "service-user": "odw-service-user-wake-sub",
+
+    "appeal-document": "appeal-document-odw-wake-sub",
+    "appeal-has": "appeal-has-odw-wake-sub",
+    "appeal-event": "appeal-event-odw-wake-sub",
+    "appeal-event-estimate": "appeal-event-estimate-odw-wake-sub",
+    "appeal-service-user": "appeal-service-user-odw-wake-sub",
+    "appeal-s78": "appeal-s78-odw-wake-sub",
+    "appeal-representation": "appeal-representation-odw-wake-sub",
+}
+
 
 @dataclass(frozen=True)
 class EntitySpec:
@@ -37,7 +67,7 @@ class EntitySpec:
     # HTTP pull uses explicit namespace env vars
     http_namespace_env_var: str
 
-    # Storage folder name override (rare cases - I think like nsip-project)
+    # Storage folder name override for rare cases where raw folder differs from topic
     storage_entity_override: Optional[str] = None
 
     # HTTP route override (normally key without hyphens)
@@ -73,12 +103,6 @@ def build_entity_spec(entity_key: str) -> EntitySpec:
 
     schema_filename = f"{entity_key}.schema.json"
 
-    # overriding schemas here for entity_key naming that don't match their schema
-    SCHEMA_OVERRIDES = {
-        "appeal-service-user": "service-user.schema.json",
-        "nsip-s51-advice": "s51-advice.schema.json",
-    }
-
     schema_filename = SCHEMA_OVERRIDES.get(entity_key, schema_filename)
 
     if _is_appeals_entity(entity_key):
@@ -92,20 +116,9 @@ def build_entity_spec(entity_key: str) -> EntitySpec:
     if entity_key == "nsip-s51-advice":
         http_route = "s51advice"
 
-    storage_override = None
-    if entity_key == "nsip-s51-advice":
-        storage_override = "s51-advice"
-    if entity_key == "appeal-service-user":
-        storage_override = "service-user"
-    if entity_key == "appeal-s78":
-        storage_override = "appeal-s78"
-    if entity_key == "appeal-representation":
-        storage_override = "appeal-representation"
+    storage_override = STORAGE_OVERRIDES.get(entity_key)
 
-    # Wake subscription (pilot only for now)
-    wake_subscription = None
-    if entity_key == "appeal-document":
-        wake_subscription = "appeal-document-odw-wake-sub"
+    wake_subscription = WAKE_SUBSCRIPTION_OVERRIDES.get(entity_key)
 
     return EntitySpec(
         key=entity_key,

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -8,13 +8,10 @@ This module is intentionally thin:
 """
 
 from __future__ import annotations
-
 import json
 import os
 from typing import Callable
-
 import azure.functions as func
-
 from pins_data_model import load_schemas
 from var_funcs import CREDENTIAL
 from set_environment import config
@@ -44,7 +41,23 @@ _app = func.FunctionApp()
 
 # Pilot toggle Wake & Drain
 # Later: set to all entities OR via env var (which would be better tbh)
-_WAKE_DRAIN_ENABLED_ENTITY_KEYS = {"appeal-document"}
+_WAKE_DRAIN_ENABLED_ENTITY_KEYS = {
+    "nsip-document",
+    "nsip-exam-timetable",
+    "nsip-project",
+    "nsip-project-update",
+    "nsip-representation",
+    "nsip-s51-advice",
+    "nsip-subscription",
+    "service-user",
+    "appeal-document",
+    "appeal-has",
+    "appeal-event",
+    "appeal-event-estimate",
+    "appeal-service-user",
+    "appeal-s78",
+    "appeal-representation",
+}
 
 
 def _make_http_pull_handler(entity: EntitySpec) -> Callable[[func.HttpRequest], func.HttpResponse]:

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -18,6 +18,7 @@ from set_environment import config
 from servicebus_funcs import get_messages_and_validate, send_to_storage
 from entity_registry import EntitySpec, all_entities
 from sb_wake_drain_processor import process_wake_and_drain
+from entity_registry import _WAKE_SUBSCRIPTION_OVERRIDES
 
 # Environment
 try:
@@ -39,26 +40,7 @@ _SCHEMAS = load_schemas.load_all_schemas()["schemas"]
 
 _app = func.FunctionApp()
 
-# Pilot toggle Wake & Drain
-# Later: set to all entities OR via env var (which would be better tbh)
-_WAKE_DRAIN_ENABLED_ENTITY_KEYS = {
-    "nsip-document",
-    "nsip-exam-timetable",
-    "nsip-project",
-    "nsip-project-update",
-    "nsip-representation",
-    "nsip-s51-advice",
-    "nsip-subscription",
-    "service-user",
-    "appeal-document",
-    "appeal-has",
-    "appeal-event",
-    "appeal-event-estimate",
-    "appeal-service-user",
-    "appeal-s78",
-    "appeal-representation",
-}
-
+_WAKE_DRAIN_ENABLED_ENTITY_KEYS = set(_WAKE_SUBSCRIPTION_OVERRIDES.keys())
 
 def _make_http_pull_handler(entity: EntitySpec) -> Callable[[func.HttpRequest], func.HttpResponse]:
     """


### PR DESCRIPTION
[THEODW-2808](https://pins-ds.atlassian.net/browse/THEODW-2808)

Implemented Wake & Drain across all configured Service Bus entities in the ODW Azure Functions ingestion layer except "Folder".

The Function App can now dynamically register Wake & Drain Service Bus triggers for all configured entities while continuing to:

- drain from the real ODW subscriptions
- wake from lightweight wake subscriptions
- preserve custom DLQ/error handling logic
- route messages to the correct raw storage locations