### PR TITLE
feat: add application-update (Crown Dev) entity with aligned subscription naming

### DIFF
--- a/functions/entity_registry.py
+++ b/functions/entity_registry.py
@@ -42,7 +42,7 @@ _WAKE_SUBSCRIPTION_OVERRIDES = {
     "nsip-s51-advice": "odw-nsip-s51-advice-wake-sub",
     "nsip-subscription": "odw-nsip-subscription-wake-sub",
     "service-user": "odw-service-user-wake-sub",
-    "application-update": "planning-environmental-specialist-odw-sub",
+    "application-update": "planning-environmental-specialist-odw-wake-sub",
 
     "appeal-document": "appeal-document-odw-wake-sub",
     "appeal-has": "appeal-has-odw-wake-sub",
@@ -51,7 +51,6 @@ _WAKE_SUBSCRIPTION_OVERRIDES = {
     "appeal-service-user": "appeal-service-user-odw-wake-sub",
     "appeal-s78": "appeal-s78-odw-wake-sub",
     "appeal-representation": "appeal-representation-odw-wake-sub",
-    "application-update": "application-update-odw-wake-sub"
 }
 
 


### PR DESCRIPTION
## Summary

- Configures drain subscription as `planning-environmental-specialist-odw-sub`
- Configures wake subscription as `planning-environmental-specialist-odw-wake-sub`, aligning both subscriptions to the same naming convention
- Removes a duplicate `application-update` key in `_WAKE_SUBSCRIPTION_OVERRIDES` that was incorrectly pointing to the drain subscription

## Changes

- `config.yaml`: adds `application-update` entity with topic `application-update` and drain subscription `planning-environmental-specialist-odw-sub`
- `entity_registry.py`: single wake subscription entry `planning-environmental-specialist-odw-wake-sub`, consistent with the drain subscription naming

## Test plan

- [ ] Confirm `planning-environmental-specialist-odw-sub` drain subscription exists in Azure Service Bus
- [ ] Confirm `planning-environmental-specialist-odw-wake-sub` wake subscription exists in Azure Service Bus
- [ ] Verify function app picks up `application-update` messages in Dev and Test after deployment
- [ ] Restart and refresh Function Apps in Prod after deployment to register the new functions