### PR TITLE
fix/disable application-update

### DIFF
--- a/functions/config.yaml
+++ b/functions/config.yaml
@@ -44,10 +44,6 @@ global:
       topic: "nsip-project-update"
       subscription: "odw-nsip-project-update-sub"
 
-    application-update:
-      topic: "application-update"
-      subscription: "planning-environmental-specialist-odw-sub"
-
     nsip-representation:
       topic: "nsip-representation"
       subscription: "odw-nsip-representation-sub"

--- a/functions/entity_registry.py
+++ b/functions/entity_registry.py
@@ -42,7 +42,6 @@ _WAKE_SUBSCRIPTION_OVERRIDES = {
     "nsip-s51-advice": "odw-nsip-s51-advice-wake-sub",
     "nsip-subscription": "odw-nsip-subscription-wake-sub",
     "service-user": "odw-service-user-wake-sub",
-    "application-update": "planning-environmental-specialist-odw-wake-sub",
 
     "appeal-document": "appeal-document-odw-wake-sub",
     "appeal-has": "appeal-has-odw-wake-sub",


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/THEODW-3079?focusedCommentId=121787

Temporarily disables application-update in DEV to stop repeated App Insights errors caused by a missing wake subscription. The function is currently trying to access application-update/Subscriptions/planning-environmental-specialist-odw-wake-sub in the pins-sb-back-office-dev-ukw-001 namespace, which is returning 404 MessagingEntityNotFound. Disabling it prevents further noise and failed lookups until the intended ServiceBus namespace and subscription configuration for application-update is confirmed and correct.