### PR TITLE
Add application update service bus topic and subscription

### DIFF
--- a/functions/config.yaml
+++ b/functions/config.yaml
@@ -44,6 +44,10 @@ global:
       topic: "nsip-project-update"
       subscription: "odw-nsip-project-update-sub"
 
+    application-update:
+      topic: "application-update"
+      subscription: "planning-environmental-specialist-odw-sub"
+
     nsip-representation:
       topic: "nsip-representation"
       subscription: "odw-nsip-representation-sub"

--- a/functions/entity_registry.py
+++ b/functions/entity_registry.py
@@ -42,6 +42,7 @@ _WAKE_SUBSCRIPTION_OVERRIDES = {
     "nsip-s51-advice": "odw-nsip-s51-advice-wake-sub",
     "nsip-subscription": "odw-nsip-subscription-wake-sub",
     "service-user": "odw-service-user-wake-sub",
+    "application-update": "application-update-odw-wake-sub",
 
     "appeal-document": "appeal-document-odw-wake-sub",
     "appeal-has": "appeal-has-odw-wake-sub",
@@ -95,6 +96,10 @@ def _is_appeals_entity(entity_key: str) -> bool:
     return entity_key.startswith("appeal-")
 
 
+def _uses_odw_service_bus_namespace(entity_key: str) -> bool:
+    return entity_key == "application-update"
+
+
 def build_entity_spec(entity_key: str) -> EntitySpec:
     """
     Build EntitySpec from config.yaml
@@ -110,6 +115,9 @@ def build_entity_spec(entity_key: str) -> EntitySpec:
     if _is_appeals_entity(entity_key):
         sb_connection = "ServiceBusConnectionAppeals"
         http_namespace_env_var = "SERVICEBUS_NAMESPACE_APPEALS"
+    elif _uses_odw_service_bus_namespace(entity_key):
+        sb_connection = "ServiceBusConnectionOdw"
+        http_namespace_env_var = "ServiceBusConnectionOdw__fullyQualifiedNamespace"
     else:
         sb_connection = "ServiceBusConnection"
         http_namespace_env_var = "ServiceBusConnection__fullyQualifiedNamespace"

--- a/functions/entity_registry.py
+++ b/functions/entity_registry.py
@@ -53,6 +53,8 @@ _WAKE_SUBSCRIPTION_OVERRIDES = {
     "appeal-representation": "appeal-representation-odw-wake-sub",
 }
 
+_ODW_NAMESPACE_ENTITIES: frozenset[str] = frozenset({"application-update"})
+
 
 @dataclass(frozen=True)
 class EntitySpec:
@@ -97,7 +99,7 @@ def _is_appeals_entity(entity_key: str) -> bool:
 
 
 def _uses_odw_service_bus_namespace(entity_key: str) -> bool:
-    return entity_key == "application-update"
+    return entity_key in _ODW_NAMESPACE_ENTITIES
 
 
 def build_entity_spec(entity_key: str) -> EntitySpec:


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/THEODW-3079

Function app was unable to consume application-update messages from the ODW SB namespace because routing logic to direct application-update to the dedicated ODW SB connection needed to be added and Function app only had connections for NSIP (default) and Appeals namespaces.

In this PR, added support for application-update entity with dedicated ODW SB routing:
1. Entity registration (config.yaml): Added application-update entity declaration, maps to ODW namespace topic (`application-update`) and maps to subscription (`planning-environmental-specialist-odw-sub`)
2. Wake subscription (entity_registry.py): Added wake subscription and enables batch processing for this entity
3. Service bus connection routing (entity_registry.py): Added helper function _uses_odw_service_bus_namespace() to identify ODW entities, modified build_entity_spec() to route `application-update` to `ServiceBusConnectionOdw` connection and uses dedicated environment variable `ServiceBusConnectionOdw__fullyQualifiedNamespace`

This requires infrastructure changes (adds `ServiceBusConnectionOdw` app setting to Function app)