### PR TITLE
fix: reduce wake/drain log volume with operation_id and batch summary

### DIFF
--- a/functions/sb_wake_drain_processor.py
+++ b/functions/sb_wake_drain_processor.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+import uuid
 from datetime import datetime, timezone
 from typing import Any, Optional
 
@@ -97,18 +98,23 @@ def process_wake_and_drain(
     - We drain the REAL subscription (entity.subscription e.g appeal-document-odw-sub)
     - If the function returns successfully, the wake message is auto completed by Functions runtime (meaning goes away from SB sub queue)
     """
+    operation_id = str(uuid.uuid4())
+
     logging.info(
-        "WAKE_DRAIN TRIGGERED entity=%s topic=%s wake_sub=%s drain_sub=%s",
+        "WAKE_DRAIN TRIGGERED entity=%s topic=%s wake_sub=%s drain_sub=%s operation_id=%s",
         entity.key,
         entity.topic,
         entity.trigger_subscription,
         entity.subscription,
+        operation_id,
     )
 
     if not namespace:
         raise ValueError(f"Missing Service Bus namespace env var for entity={entity.key}")
 
     drained_total = 0
+    success_count = 0
+    failure_count = 0
 
     # Drain loop: receive batches until empty or hit max_message_count
     try:
@@ -134,7 +140,7 @@ def process_wake_and_drain(
 
                     for msg in messages:
                         drained_total += 1
-                        _process_one_message(
+                        ok = _process_one_message(
                             receiver=receiver,
                             msg=msg,
                             entity=entity,
@@ -142,16 +148,28 @@ def process_wake_and_drain(
                             storage_account_url=storage_account_url,
                             storage_container=storage_container,
                             credential=credential,
+                            operation_id=operation_id,
                         )
+                        if ok:
+                            success_count += 1
+                        else:
+                            failure_count += 1
 
     except ServiceBusError as e:
-        logging.exception("WAKE_DRAIN SERVICEBUS_ERROR entity=%s error=%s", entity.key, str(e))
+        logging.exception("WAKE_DRAIN SERVICEBUS_ERROR entity=%s error=%s operation_id=%s", entity.key, str(e), operation_id)
         raise
     except Exception as e:
-        logging.exception("WAKE_DRAIN UNEXPECTED_ERROR entity=%s error=%s", entity.key, str(e))
+        logging.exception("WAKE_DRAIN UNEXPECTED_ERROR entity=%s error=%s operation_id=%s", entity.key, str(e), operation_id)
         raise
 
-    logging.info("WAKE_DRAIN DONE entity=%s drained_total=%s", entity.key, drained_total)
+    logging.info(
+        "WAKE_DRAIN DONE entity=%s drained_total=%s success=%s failed=%s operation_id=%s",
+        entity.key,
+        drained_total,
+        success_count,
+        failure_count,
+        operation_id,
+    )
 
 
 def _process_one_message(
@@ -163,7 +181,8 @@ def _process_one_message(
     storage_account_url: str,
     storage_container: str,
     credential: Any,
-) -> None:
+    operation_id: str,
+) -> bool:
     """
     Process ONE message from the REAL subscription
     - JSON parse
@@ -184,7 +203,7 @@ def _process_one_message(
             reason="BodyReadFailed",
             description="Could not read message body bytes/utf-8 decode.",
         )
-        return
+        return False
 
     try:
         payload = json.loads(body_text)
@@ -195,7 +214,7 @@ def _process_one_message(
             reason="InvalidJson",
             description=f"JSON deserialization failed: {str(e)}. Body(sample)={body_text[:500]}",
         )
-        return
+        return False
 
     errors = validate_data(payload, schema)
     if errors:
@@ -206,7 +225,7 @@ def _process_one_message(
             reason="SchemaValidationFailed",
             description=f"{errors_joined}",
         )
-        return
+        return False
 
     msg_type = _extract_message_type(msg)
 
@@ -229,20 +248,15 @@ def _process_one_message(
             data=[payload],
         )
         receiver.complete_message(msg)
-
-        logging.info(
-            "WAKE_DRAIN OK entity=%s message_id=%s delivery_count=%s",
-            entity.key,
-            message_id,
-            delivery_count,
-        )
+        return True
     except Exception as e:
         # If storage write fails we don't complete
         # Let the message be retried we do not DLQ infra problems here
         logging.exception(
-            "WAKE_DRAIN STORAGE_WRITE_FAILED entity=%s message_id=%s error=%s",
+            "WAKE_DRAIN STORAGE_WRITE_FAILED entity=%s message_id=%s error=%s operation_id=%s",
             entity.key,
             message_id,
             str(e),
+            operation_id,
         )
         raise

--- a/functions/sb_wake_drain_processor.py
+++ b/functions/sb_wake_drain_processor.py
@@ -100,21 +100,10 @@ def process_wake_and_drain(
     """
     operation_id = str(uuid.uuid4())
 
-    logging.info(
-        "WAKE_DRAIN TRIGGERED entity=%s topic=%s wake_sub=%s drain_sub=%s operation_id=%s",
-        entity.key,
-        entity.topic,
-        entity.trigger_subscription,
-        entity.subscription,
-        operation_id,
-    )
-
     if not namespace:
         raise ValueError(f"Missing Service Bus namespace env var for entity={entity.key}")
 
     drained_total = 0
-    success_count = 0
-    failure_count = 0
 
     # Drain loop: receive batches until empty or hit max_message_count
     try:
@@ -140,7 +129,7 @@ def process_wake_and_drain(
 
                     for msg in messages:
                         drained_total += 1
-                        ok = _process_one_message(
+                        _process_one_message(
                             receiver=receiver,
                             msg=msg,
                             entity=entity,
@@ -150,10 +139,6 @@ def process_wake_and_drain(
                             credential=credential,
                             operation_id=operation_id,
                         )
-                        if ok:
-                            success_count += 1
-                        else:
-                            failure_count += 1
 
     except ServiceBusError as e:
         logging.exception("WAKE_DRAIN SERVICEBUS_ERROR entity=%s error=%s operation_id=%s", entity.key, str(e), operation_id)
@@ -161,15 +146,6 @@ def process_wake_and_drain(
     except Exception as e:
         logging.exception("WAKE_DRAIN UNEXPECTED_ERROR entity=%s error=%s operation_id=%s", entity.key, str(e), operation_id)
         raise
-
-    logging.info(
-        "WAKE_DRAIN DONE entity=%s drained_total=%s success=%s failed=%s operation_id=%s",
-        entity.key,
-        drained_total,
-        success_count,
-        failure_count,
-        operation_id,
-    )
 
 
 def _process_one_message(


### PR DESCRIPTION
## Summary

- Replaces the per-message `WAKE_DRAIN OK` `logging.info()` call (emitted once per message processed) with a single `WAKE_DRAIN DONE` summary line containing `success` and `failed` counts — reducing trace output from N logs per invocation to 2 (TRIGGERED + DONE)
- Adds `operation_id` (UUID) generated at the start of each `process_wake_and_drain()` invocation and stamped on all log lines (TRIGGERED, DONE, SERVICEBUS_ERROR, UNEXPECTED_ERROR, STORAGE_WRITE_FAILED), enabling Kusto correlation without relying on the Functions InvocationId
- `_process_one_message()` now returns `bool` (`True` = storage write succeeded, `False` = dead-lettered); the drain loop accumulates the counts

## Context

Part of THEODW-3322 / THEODW-3291. The wake & drain function was emitting one `WAKE_DRAIN OK` trace per message, which — combined with a double Log Analytics export path (see companion PR in odw-infrastructure) — was driving unusually high ingestion volume approaching the 0.2 GB cap and risking suppression of main pipeline logs.

## Test plan

- [ ] Trigger a controlled drain of one entity (e.g. `nsip-document`) and confirm Log Analytics shows exactly 2 `WAKE_DRAIN` trace rows per invocation (TRIGGERED + DONE), not N
- [ ] Confirm `operation_id` field is present on all emitted log lines for the same invocation
- [ ] Verify dead-lettered messages (BodyReadFailed / InvalidJson / SchemaValidationFailed) are reflected in the `failed` count in WAKE_DRAIN DONE
- [ ] Confirm existing Kusto queries and alerts that reference `WAKE_DRAIN` log messages still function correctly