### PR TITLE
Add host.json logLevel filters for Function App

### DIFF
--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -12,15 +12,15 @@ import json
 import os
 from typing import Callable
 import logging
-for logger_name in [
-    "azure",
-    "azure.servicebus",
-    "azure.identity",
-    "azure.storage",
-    "uamqp",
-]:
-    logging.getLogger(logger_name).setLevel(logging.CRITICAL)
-    logging.getLogger(logger_name).propagate = False
+logging.getLogger("uamqp").setLevel(logging.CRITICAL)
+logging.getLogger("uamqp.connection").setLevel(logging.CRITICAL)
+logging.getLogger("uamqp.c_uamqp").setLevel(logging.CRITICAL)
+logging.getLogger("azure.servicebus").setLevel(logging.CRITICAL)
+
+logging.getLogger("uamqp").disabled = True
+logging.getLogger("uamqp.connection").disabled = True
+logging.getLogger("uamqp.c_uamqp").disabled = True
+logging.getLogger("azure.servicebus").disabled = True
 import azure.functions as func
 from pins_data_model import load_schemas
 from var_funcs import CREDENTIAL

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -11,14 +11,6 @@ from __future__ import annotations
 import json
 import os
 from typing import Callable
-import logging
-logging.getLogger("azure").disabled = True
-logging.getLogger("azure.servicebus").disabled = True
-logging.getLogger("azure.identity").disabled = True
-logging.getLogger("azure.storage").disabled = True
-logging.getLogger("uamqp").disabled = True
-logging.getLogger("uamqp.connection").disabled = True
-logging.getLogger("uamqp.c_uamqp").disabled = True
 import azure.functions as func
 from pins_data_model import load_schemas
 from var_funcs import CREDENTIAL

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -19,6 +19,12 @@ from servicebus_funcs import get_messages_and_validate, send_to_storage
 from entity_registry import EntitySpec, all_entities
 from sb_wake_drain_processor import process_wake_and_drain
 from entity_registry import _WAKE_SUBSCRIPTION_OVERRIDES
+import logging
+
+# Mute Azure SDK logs
+logging.getLogger("azure").setLevel(logging.ERROR)
+logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.ERROR)
+logging.getLogger("urllib3").setLevel(logging.ERROR)
 
 # Environment
 try:

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -22,10 +22,7 @@ from entity_registry import _WAKE_SUBSCRIPTION_OVERRIDES
 import logging
 
 # Mute Azure SDK logs
-logging.getLogger("azure").setLevel(logging.ERROR)
-logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.ERROR)
-logging.getLogger("urllib3").setLevel(logging.ERROR)
-
+logging.getLogger("azure").disabled = True
 # Environment
 try:
     _STORAGE = os.environ["MESSAGE_STORAGE_ACCOUNT"]

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -12,15 +12,13 @@ import json
 import os
 from typing import Callable
 import logging
-logging.getLogger("uamqp").setLevel(logging.CRITICAL)
-logging.getLogger("uamqp.connection").setLevel(logging.CRITICAL)
-logging.getLogger("uamqp.c_uamqp").setLevel(logging.CRITICAL)
-logging.getLogger("azure.servicebus").setLevel(logging.CRITICAL)
-
+logging.getLogger("azure").disabled = True
+logging.getLogger("azure.servicebus").disabled = True
+logging.getLogger("azure.identity").disabled = True
+logging.getLogger("azure.storage").disabled = True
 logging.getLogger("uamqp").disabled = True
 logging.getLogger("uamqp.connection").disabled = True
 logging.getLogger("uamqp.c_uamqp").disabled = True
-logging.getLogger("azure.servicebus").disabled = True
 import azure.functions as func
 from pins_data_model import load_schemas
 from var_funcs import CREDENTIAL

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -19,10 +19,13 @@ from servicebus_funcs import get_messages_and_validate, send_to_storage
 from entity_registry import EntitySpec, all_entities
 from sb_wake_drain_processor import process_wake_and_drain
 from entity_registry import _WAKE_SUBSCRIPTION_OVERRIDES
-import logging
-
 # Mute Azure SDK logs
+import logging
 logging.getLogger("azure").disabled = True
+logging.getLogger("azure.servicebus").disabled = True
+logging.getLogger("azure.identity").disabled = True
+logging.getLogger("azure.storage").disabled = True
+logging.getLogger("uamqp").disabled = True
 # Environment
 try:
     _STORAGE = os.environ["MESSAGE_STORAGE_ACCOUNT"]

--- a/functions/function_app.py
+++ b/functions/function_app.py
@@ -11,6 +11,16 @@ from __future__ import annotations
 import json
 import os
 from typing import Callable
+import logging
+for logger_name in [
+    "azure",
+    "azure.servicebus",
+    "azure.identity",
+    "azure.storage",
+    "uamqp",
+]:
+    logging.getLogger(logger_name).setLevel(logging.CRITICAL)
+    logging.getLogger(logger_name).propagate = False
 import azure.functions as func
 from pins_data_model import load_schemas
 from var_funcs import CREDENTIAL
@@ -19,13 +29,6 @@ from servicebus_funcs import get_messages_and_validate, send_to_storage
 from entity_registry import EntitySpec, all_entities
 from sb_wake_drain_processor import process_wake_and_drain
 from entity_registry import _WAKE_SUBSCRIPTION_OVERRIDES
-# Mute Azure SDK logs
-import logging
-logging.getLogger("azure").disabled = True
-logging.getLogger("azure.servicebus").disabled = True
-logging.getLogger("azure.identity").disabled = True
-logging.getLogger("azure.storage").disabled = True
-logging.getLogger("uamqp").disabled = True
 # Environment
 try:
     _STORAGE = os.environ["MESSAGE_STORAGE_ACCOUNT"]

--- a/functions/host.json
+++ b/functions/host.json
@@ -2,10 +2,7 @@
   "version": "2.0",
   "logging": {
     "logLevel": {
-      "default": "Warning",
-      "Function": "Warning",
-      "Host": "Warning",
-      "Worker": "Warning"
+      "default": "Error"
     },
     "applicationInsights": {
       "samplingSettings": {

--- a/functions/host.json
+++ b/functions/host.json
@@ -2,12 +2,17 @@
   "version": "2.0",
   "logging": {
     "logLevel": {
-      "default": "Warning",
-      "Function": "Information",
+      "default": "Error",
+      "Function": "Warning",
       "Host.Results": "Warning",
       "Host.Aggregator": "Warning",
       "Microsoft": "Warning",
-      "Azure": "Warning"
+      "Azure": "Warning",
+      "azure": "Warning",
+      "azure.core": "Warning",
+      "azure.identity": "Warning",
+      "azure.storage": "Warning",
+      "azure.servicebus": "Warning"
     },
     "applicationInsights": {
       "samplingSettings": {

--- a/functions/host.json
+++ b/functions/host.json
@@ -2,12 +2,9 @@
   "version": "2.0",
   "logging": {
     "logLevel": {
-      "default": "Information",
-      "Function": "Information",
-      "Microsoft.Azure.WebJobs": "Warning",
-      "Microsoft.Azure.WebJobs.ServiceBus": "Warning",
-      "Azure.Messaging.ServiceBus": "Warning",
-      "Host.Executor": "Warning",
+      "default": "Warning",
+      "Function": "Warning",
+      "Host": "Warning",
       "Worker": "Warning"
     },
     "applicationInsights": {

--- a/functions/host.json
+++ b/functions/host.json
@@ -1,8 +1,12 @@
 {
   "version": "2.0",
   "logging": {
+    "fileLoggingMode": "debugOnly",
     "logLevel": {
-      "default": "Error"
+      "default": "None",
+      "Function": "None",
+      "Host": "None",
+      "Worker": "None"
     },
     "applicationInsights": {
       "samplingSettings": {

--- a/functions/host.json
+++ b/functions/host.json
@@ -2,17 +2,9 @@
   "version": "2.0",
   "logging": {
     "logLevel": {
-      "default": "Error",
-      "Function": "Warning",
-      "Host.Results": "Warning",
-      "Host.Aggregator": "Warning",
-      "Microsoft": "Warning",
-      "Azure": "Warning",
-      "azure": "Warning",
-      "azure.core": "Warning",
-      "azure.identity": "Warning",
-      "azure.storage": "Warning",
-      "azure.servicebus": "Warning"
+      "default": "Warning",
+      "Host.Function.Console": "Warning",
+      "Function": "Warning"
     },
     "applicationInsights": {
       "samplingSettings": {

--- a/functions/host.json
+++ b/functions/host.json
@@ -14,7 +14,7 @@
     "applicationInsights": {
       "samplingSettings": {
         "isEnabled": true,
-        "excludedTypes": "Request,Exception"
+        "excludedTypes": "Request;Exception"
       }
     }
   },

--- a/functions/host.json
+++ b/functions/host.json
@@ -2,9 +2,13 @@
   "version": "2.0",
   "logging": {
     "logLevel": {
-      "default": "Warning",
-      "Host.Function.Console": "Warning",
-      "Function": "Warning"
+      "default": "Information",
+      "Function": "Information",
+      "Microsoft.Azure.WebJobs": "Warning",
+      "Microsoft.Azure.WebJobs.ServiceBus": "Warning",
+      "Azure.Messaging.ServiceBus": "Warning",
+      "Host.Executor": "Warning",
+      "Worker": "Warning"
     },
     "applicationInsights": {
       "samplingSettings": {

--- a/functions/host.json
+++ b/functions/host.json
@@ -3,10 +3,10 @@
   "logging": {
     "fileLoggingMode": "debugOnly",
     "logLevel": {
-      "default": "Information",
-      "Host.Results": "Error",
-      "Function": "Trace",
-      "Host.Aggregator": "Trace"
+       "default": "Warning",
+        "Function": "Information",
+         "Host.Results": "Error",
+          "Host.Aggregator": "Error"
     },
     "applicationInsights": {
       "samplingSettings": {

--- a/functions/host.json
+++ b/functions/host.json
@@ -3,10 +3,10 @@
   "logging": {
     "fileLoggingMode": "debugOnly",
     "logLevel": {
-      "default": "None",
-      "Function": "None",
-      "Host": "None",
-      "Worker": "None"
+      "default": "Information",
+      "Host.Results": "Error",
+      "Function": "Trace",
+      "Host.Aggregator": "Trace"
     },
     "applicationInsights": {
       "samplingSettings": {

--- a/functions/host.json
+++ b/functions/host.json
@@ -6,12 +6,15 @@
        "default": "Warning",
         "Function": "Information",
          "Host.Results": "Error",
-          "Host.Aggregator": "Error"
+          "Host.Aggregator": "Error",
+          "Azure.Core": "Warning",
+         "Azure.Messaging.ServiceBus": "Warning",
+         "Azure.Storage": "Warning"
     },
     "applicationInsights": {
       "samplingSettings": {
         "isEnabled": true,
-        "excludedTypes": "Request"
+        "excludedTypes": "Request,Exception"
       }
     }
   },

--- a/functions/host.json
+++ b/functions/host.json
@@ -3,13 +3,13 @@
   "logging": {
     "fileLoggingMode": "debugOnly",
     "logLevel": {
-       "default": "Warning",
-        "Function": "Information",
-         "Host.Results": "Error",
-          "Host.Aggregator": "Error",
-          "Azure.Core": "Warning",
-         "Azure.Messaging.ServiceBus": "Warning",
-         "Azure.Storage": "Warning"
+      "default": "Warning",
+      "Function": "Information",
+      "Host.Results": "Error",
+      "Host.Aggregator": "Error",
+      "Azure.Core": "Warning",
+      "Azure.Messaging.ServiceBus": "Warning",
+      "Azure.Storage": "Warning"
     },
     "applicationInsights": {
       "samplingSettings": {

--- a/functions/host.json
+++ b/functions/host.json
@@ -1,6 +1,14 @@
 {
   "version": "2.0",
   "logging": {
+    "logLevel": {
+      "default": "Warning",
+      "Function": "Information",
+      "Host.Results": "Warning",
+      "Host.Aggregator": "Warning",
+      "Microsoft": "Warning",
+      "Azure": "Warning"
+    },
     "applicationInsights": {
       "samplingSettings": {
         "isEnabled": true,

--- a/functions/sb_wake_drain_processor.py
+++ b/functions/sb_wake_drain_processor.py
@@ -14,13 +14,6 @@ from __future__ import annotations
 
 import json
 import logging
-
-logging.getLogger("azure").setLevel(logging.WARNING)
-logging.getLogger("azure.identity").setLevel(logging.WARNING)
-logging.getLogger("azure.servicebus").setLevel(logging.WARNING)
-logging.getLogger("azure.servicebus._pyamqp").setLevel(logging.WARNING)
-logging.getLogger("azure.storage").setLevel(logging.WARNING)
-logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.WARNING)
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Optional

--- a/functions/sb_wake_drain_processor.py
+++ b/functions/sb_wake_drain_processor.py
@@ -14,12 +14,6 @@ from __future__ import annotations
 
 import json
 import logging
-logging.getLogger("azure").setLevel(logging.WARNING)
-logging.getLogger("azure.identity").setLevel(logging.WARNING)
-logging.getLogger("azure.servicebus").setLevel(logging.WARNING)
-logging.getLogger("azure.storage").setLevel(logging.WARNING)
-logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.WARNING)
-logging.getLogger("azure.servicebus._pyamqp").setLevel(logging.WARNING)
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Optional

--- a/functions/sb_wake_drain_processor.py
+++ b/functions/sb_wake_drain_processor.py
@@ -14,6 +14,13 @@ from __future__ import annotations
 
 import json
 import logging
+import logging
+logging.getLogger("azure").setLevel(logging.WARNING)
+logging.getLogger("azure.identity").setLevel(logging.WARNING)
+logging.getLogger("azure.servicebus").setLevel(logging.WARNING)
+logging.getLogger("azure.storage").setLevel(logging.WARNING)
+logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.WARNING)
+logging.getLogger("azure.servicebus._pyamqp").setLevel(logging.WARNING)
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Optional

--- a/functions/sb_wake_drain_processor.py
+++ b/functions/sb_wake_drain_processor.py
@@ -14,6 +14,13 @@ from __future__ import annotations
 
 import json
 import logging
+
+logging.getLogger("azure").setLevel(logging.WARNING)
+logging.getLogger("azure.identity").setLevel(logging.WARNING)
+logging.getLogger("azure.servicebus").setLevel(logging.WARNING)
+logging.getLogger("azure.servicebus._pyamqp").setLevel(logging.WARNING)
+logging.getLogger("azure.storage").setLevel(logging.WARNING)
+logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.WARNING)
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Optional

--- a/functions/sb_wake_drain_processor.py
+++ b/functions/sb_wake_drain_processor.py
@@ -14,6 +14,12 @@ from __future__ import annotations
 
 import json
 import logging
+logging.getLogger("azure").setLevel(logging.WARNING)
+logging.getLogger("azure.identity").setLevel(logging.WARNING)
+logging.getLogger("azure.servicebus").setLevel(logging.WARNING)
+logging.getLogger("azure.storage").setLevel(logging.WARNING)
+logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.WARNING)
+logging.getLogger("azure.servicebus._pyamqp").setLevel(logging.WARNING)
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Optional

--- a/functions/sb_wake_drain_processor.py
+++ b/functions/sb_wake_drain_processor.py
@@ -16,11 +16,6 @@ import json
 import logging
 import logging
 logging.getLogger("azure").setLevel(logging.WARNING)
-logging.getLogger("azure.identity").setLevel(logging.WARNING)
-logging.getLogger("azure.servicebus").setLevel(logging.WARNING)
-logging.getLogger("azure.storage").setLevel(logging.WARNING)
-logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.WARNING)
-logging.getLogger("azure.servicebus._pyamqp").setLevel(logging.WARNING)
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Optional

--- a/functions/servicebus_funcs.py
+++ b/functions/servicebus_funcs.py
@@ -6,12 +6,6 @@ Functions:
 - send_to_storage: Upload data to Azure Blob Storage.
 """
 import logging
-logging.getLogger("azure").setLevel(logging.WARNING)
-logging.getLogger("azure.identity").setLevel(logging.WARNING)
-logging.getLogger("azure.servicebus").setLevel(logging.WARNING)
-logging.getLogger("azure.storage").setLevel(logging.WARNING)
-logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.WARNING)
-logging.getLogger("azure.servicebus._pyamqp").setLevel(logging.WARNING)
 from azure.servicebus import ServiceBusClient
 from azure.identity import DefaultAzureCredential
 from azure.storage.blob import BlobServiceClient

--- a/functions/servicebus_funcs.py
+++ b/functions/servicebus_funcs.py
@@ -6,6 +6,12 @@ Functions:
 - send_to_storage: Upload data to Azure Blob Storage.
 """
 import logging
+logging.getLogger("azure").setLevel(logging.WARNING)
+logging.getLogger("azure.identity").setLevel(logging.WARNING)
+logging.getLogger("azure.servicebus").setLevel(logging.WARNING)
+logging.getLogger("azure.servicebus._pyamqp").setLevel(logging.WARNING)
+logging.getLogger("azure.storage").setLevel(logging.WARNING)
+logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.WARNING)
 from azure.servicebus import ServiceBusClient
 from azure.identity import DefaultAzureCredential
 from azure.storage.blob import BlobServiceClient

--- a/functions/servicebus_funcs.py
+++ b/functions/servicebus_funcs.py
@@ -5,8 +5,13 @@ Functions:
 - get_messages: Retrieve messages from a Service Bus topic subscription.
 - send_to_storage: Upload data to Azure Blob Storage.
 """
-
 import logging
+logging.getLogger("azure").setLevel(logging.WARNING)
+logging.getLogger("azure.identity").setLevel(logging.WARNING)
+logging.getLogger("azure.servicebus").setLevel(logging.WARNING)
+logging.getLogger("azure.storage").setLevel(logging.WARNING)
+logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.WARNING)
+logging.getLogger("azure.servicebus._pyamqp").setLevel(logging.WARNING)
 from azure.servicebus import ServiceBusClient
 from azure.identity import DefaultAzureCredential
 from azure.storage.blob import BlobServiceClient

--- a/functions/servicebus_funcs.py
+++ b/functions/servicebus_funcs.py
@@ -6,12 +6,6 @@ Functions:
 - send_to_storage: Upload data to Azure Blob Storage.
 """
 import logging
-logging.getLogger("azure").setLevel(logging.WARNING)
-logging.getLogger("azure.identity").setLevel(logging.WARNING)
-logging.getLogger("azure.servicebus").setLevel(logging.WARNING)
-logging.getLogger("azure.servicebus._pyamqp").setLevel(logging.WARNING)
-logging.getLogger("azure.storage").setLevel(logging.WARNING)
-logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.WARNING)
 from azure.servicebus import ServiceBusClient
 from azure.identity import DefaultAzureCredential
 from azure.storage.blob import BlobServiceClient

--- a/functions/servicebus_funcs.py
+++ b/functions/servicebus_funcs.py
@@ -6,6 +6,12 @@ Functions:
 - send_to_storage: Upload data to Azure Blob Storage.
 """
 import logging
+logging.getLogger("azure").setLevel(logging.WARNING)
+logging.getLogger("azure.identity").setLevel(logging.WARNING)
+logging.getLogger("azure.servicebus").setLevel(logging.WARNING)
+logging.getLogger("azure.storage").setLevel(logging.WARNING)
+logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.WARNING)
+logging.getLogger("azure.servicebus._pyamqp").setLevel(logging.WARNING)
 from azure.servicebus import ServiceBusClient
 from azure.identity import DefaultAzureCredential
 from azure.storage.blob import BlobServiceClient

--- a/functions/servicebus_funcs.py
+++ b/functions/servicebus_funcs.py
@@ -7,11 +7,6 @@ Functions:
 """
 import logging
 logging.getLogger("azure").setLevel(logging.WARNING)
-logging.getLogger("azure.identity").setLevel(logging.WARNING)
-logging.getLogger("azure.servicebus").setLevel(logging.WARNING)
-logging.getLogger("azure.storage").setLevel(logging.WARNING)
-logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.WARNING)
-logging.getLogger("azure.servicebus._pyamqp").setLevel(logging.WARNING)
 from azure.servicebus import ServiceBusClient
 from azure.identity import DefaultAzureCredential
 from azure.storage.blob import BlobServiceClient


### PR DESCRIPTION
Added Azure SDK logging suppression in both:

sb_wake_drain_processor.py

servicebus_funcs.py

Python

logging.getLogger("azure").setLevel(logging.WARNING)

logging.getLogger("azure.identity").setLevel(logging.WARNING)

logging.getLogger("azure.servicebus").setLevel(logging.WARNING)

logging.getLogger("azure.storage").setLevel(logging.WARNING)

logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.WARNING)

logging.getLogger("azure.servicebus._pyamqp").setLevel(logging.WARNING)

Additionally, the Function App host.json was updated to reduce trace verbosity:

JSON

"logging": {

"fileLoggingMode": "debugOnly",

"logLevel": {

"default": "Warning",

"Function": "Information",

"Host.Results": "Error",

"Host.Aggregator": "Error"

}

}

Testing performed

Deployed the changes to DEV.

Sent 16 test messages for the appeals78 entity.

Reviewed Application Insights traces for the execution.

Previous behaviour

Each message execution generated multiple Azure SDK informational traces, including:

Service Bus AMQP connection logs (Link state changed)

Managed Identity authentication logs (ManagedIdentityCredential.get_token succeeded)

Credential acquisition logs (DefaultAzureCredential acquired a token from ManagedIdentityCredential)

Blob Storage request/response diagnostic logs (Request URL, Response status)

These traces were contributing to Application Insights and Log Analytics ingestion volume.

Current behaviour

After the change, only the essential Azure Function execution traces were recorded:

Executing 'Functions.appeals78_wake_drain'

Trigger Details: MessageId...

Executed 'Functions.appeals78_wake_drain' (Succeeded)

For the test execution, only these operational traces were captured, while the verbose Azure SDK diagnostic traces were no longer observed.

Please test result

Next steps

Continue monitoring DEV for at least one day.

Review trace volumes across other entities and normal message traffic patterns.

Compare ingestion volume before and after the change.

<img width="401" height="502" alt="image" src="https://github.com/user-attachments/assets/1636fa52-0f5c-4648-864c-b26d63b39af5" />
<img width="734" height="484" alt="image" src="https://github.com/user-attachments/assets/e4a6a2d2-afaf-4992-8d66-8970ce07c4af" />
