### PR TITLE
update naming for application-update

### DIFF
--- a/functions/config.yaml
+++ b/functions/config.yaml
@@ -44,9 +44,9 @@ global:
       topic: "nsip-project-update"
       subscription: "odw-nsip-project-update-sub"
 
-    application-update:
-      topic: "application-update"
-      subscription: "planning-environmental-specialist-odw-sub"
+    applications-application-update:
+      topic: "applications-application-update"
+      subscription: "applications-application-update-sub"
 
     nsip-representation:
       topic: "nsip-representation"

--- a/functions/entity_registry.py
+++ b/functions/entity_registry.py
@@ -42,7 +42,7 @@ _WAKE_SUBSCRIPTION_OVERRIDES = {
     "nsip-s51-advice": "odw-nsip-s51-advice-wake-sub",
     "nsip-subscription": "odw-nsip-subscription-wake-sub",
     "service-user": "odw-service-user-wake-sub",
-    "application-update": "planning-environmental-specialist-odw-wake-sub",
+    "applications-application-update": "applications-application-update-odw-wake-sub",
 
     "appeal-document": "appeal-document-odw-wake-sub",
     "appeal-has": "appeal-has-odw-wake-sub",
@@ -53,7 +53,7 @@ _WAKE_SUBSCRIPTION_OVERRIDES = {
     "appeal-representation": "appeal-representation-odw-wake-sub",
 }
 
-_ODW_NAMESPACE_ENTITIES: frozenset[str] = frozenset({"application-update"})
+_ODW_NAMESPACE_ENTITIES: frozenset[str] = frozenset({"applications-application-update"})
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
https://pins-ds.atlassian.net/browse/THEODW-3444

The new entity definitions have been updated, we need to rename the crown dev service bus entities in line with conventions and to future-proof the eventual inclusion of s62a casework. 

As part of this, **application-update** entity has been renamed to **applications-application-update** along with the subscription and topic names (see ticket). This has been updated across all required repository's